### PR TITLE
docs: fix typo in introduction

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 Willkommen zur Lerndokumentation! In diesem Abschnitt erfährst du, wie du deine Dokumente in Docusaurus mithilfe von
 `_category_.json`-Dateien und der `sidebar_position` im Frontmatter strukturieren kannst. Weitere Details zu den
 verschiedenen Optionen findest du in der offiziellen Dokumentation
-unter in der [Docusaurus-Dokumentation](https://docusaurus.io/docs/)
+in der [Docusaurus-Dokumentation](https://docusaurus.io/docs/)
 
 ---
 


### PR DESCRIPTION
## Summary
- remove duplicated wording in introduction docs

## Testing
- `npm run format:check`
- `npm run typecheck`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689900e55c1c8332b0531c794d49ed1c